### PR TITLE
Fixing session 500 with sleeping connections

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -279,8 +279,8 @@
     "    \"Insert an object into this table, and return it\"\n",
     "    d = {**asdict(obj), **self.xtra_id}\n",
     "    result = self.conn.execute(sa.insert(self.table).values(**d).returning(*self.table.columns))\n",
-    "    row = result.one()  # Consume the result set\n",
     "    self.conn.commit()\n",
+    "    row = result.one()  # Consume the result set\n",
     "    return self.cls(**row._asdict())"
    ]
   },
@@ -368,6 +368,7 @@
     "    if limit is not None: query = query.limit(limit)\n",
     "    if offset is not None: query = query.offset(offset)\n",
     "    rows = self.conn.execute(query).all()\n",
+    "    self.conn.commit()\n",
     "    return [self.cls(**row._asdict()) for row in rows]"
    ]
   },
@@ -544,6 +545,7 @@
     "    \"Get item with PK `key`\"\n",
     "    qry = self._pk_where('select', key)\n",
     "    result = self.conn.execute(qry).first()\n",
+    "    self.conn.commit()\n",
     "    if not result: raise NotFoundError()\n",
     "    return self.cls(**result._asdict())"
    ]
@@ -597,8 +599,8 @@
     "    pks = tuple(d[k.name] for k in self.table.primary_key)\n",
     "    qry = self._pk_where('update', pks).values(**d).returning(*self.table.columns)\n",
     "    result = self.conn.execute(qry)\n",
-    "    row = result.one()\n",
     "    self.conn.commit()\n",
+    "    row = result.one()\n",
     "    return self.cls(**row._asdict())"
    ]
   },
@@ -864,7 +866,9 @@
     "@patch\n",
     "def get(self:Table, where=None, limit=None):\n",
     "    \"Select from table, optionally limited by `where` and `limit` clauses\"\n",
-    "    return self.metadata.conn.sql(self.select().where(where).limit(limit))"
+    "    result = self.metadata.conn.sql(self.select().where(where).limit(limit))\n",
+    "    self.metadata.conn.commit()\n",
+    "    return result"
    ]
   },
   {


### PR DESCRIPTION
Issue:
* fastsql fails on replit or postgreSQL with connections that timeout / sleep (includes the todo app demo on replit)

Reason:
* When a postgreSQL conn goes to sleep, fastsql fails with `psycopg2.OperationalError: SSL connection has been closed unexpectedly` triggering a 500 and does not recover until restarted. 

Solution
* Session management. I've been testing locally with a DB that sleeps after 10s so I'm positive this fixes the issue. However, I've only tested it with the basic `__call__` method. But I am not sure this approach aligns with the library design so I wanted open this early to avoid useless testing.


I also had some failures on stress testing so I added some engine params that seemed to improve performance. However, I'm not seeing this performance failures with the current setup so it might be removed. 


